### PR TITLE
Adding BOOST_USE_STATIC_LINK option at EXAMPLE_CONFIG_SITE.local.

### DIFF
--- a/configure/EXAMPLE_CONFIG_SITE.local
+++ b/configure/EXAMPLE_CONFIG_SITE.local
@@ -24,6 +24,10 @@ WITH_BOOST     = NO
 #BOOST_LIB     =
 #BOOST_INCLUDE =
 
+# Uncomment this line if you want to use STATIC Linking when buiding
+# ADCore/pluginTests unit tests.
+#BOOST_USE_STATIC_LINK=YES
+
 # EPICS_V4 is required for NDPluginPva and pvaDriver
 WITH_EPICS_V4  = YES
 


### PR DESCRIPTION
This option is used by ADCore to select wether or not to do the static link of Boost test.
Here is the ADCore pull request that uses this new option: https://github.com/areaDetector/ADCore/pull/269