### PR TITLE
Fix macOS references in Install Guide

### DIFF
--- a/INSTALL_GUIDE.md
+++ b/INSTALL_GUIDE.md
@@ -19,7 +19,7 @@ github repository.
 This guide provides instructions for:
 
 * Installing, building, and running from source code. These instructions should
-  work on any supported EPICS host architecture, e.g. Linux, Windows, Mac OSX, vxWorks. 
+  work on any supported EPICS host architecture, e.g. Linux, Windows, macOS, vxWorks. 
   This document assumes that the reader has already installed an EPICS
   development environment, and has built 
   [EPICS base](http://www.aps.anl.gov/epics/base), the 
@@ -540,7 +540,7 @@ architectures:
 - linux-x86_64 (64-bit Linux built on Centos7, gcc 4.8.5, libc 2.17)
 - linux-x86_rhel6 (32-bit Linux build on RHEL6, gcc 4.4.7, libc 2.12)
 - linux-x86_64-gcc42 (64-bit Linux built on SUSE, gcc 4.2.1, libc 2.6.1)
-- darwin-x86 (64-bit Mac OSX built on Darwin 11.4.2,  ??, clang 4.2)
+- darwin-x86 (64-bit Mac OS X built on Darwin 11.4.2,  ??, clang 4.2)
 - win32-x86-static (32-bit Windows, VS2010 compiler, statically linked)
 - win32-x86 (32-bit Windows, VX2010 compiler, dyanamically linked)
 - windows-x64-static (64-bit Windows, VS2010 compiler, statically linked)


### PR DESCRIPTION
Refer to macOS by its latest name which is "macOS". "Mac OSX" (i.e.,
without the space between "OS" and "X") was never a valid name.  For the
case where binaries for Darwin 11 are referenced, use the name as of
that release, which is "Mac OS X".