### PR TITLE
Adding ADUVC submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -153,4 +153,4 @@
 	url = https://github.com/areaDetector/ADRIXSCam.git
 [submodule "ADUVC"]
 	path = ADUVC
-	url = https://github.com/areaDetector/ADUVC.git
+	url = https://github.com/areaDetector/ADUVC

--- a/.gitmodules
+++ b/.gitmodules
@@ -151,3 +151,6 @@
 [submodule "ADRIXSCam"]
 	path = ADRIXSCam
 	url = https://github.com/areaDetector/ADRIXSCam.git
+[submodule "ADUVC"]
+	path = ADUVC
+	url = https://github.com/areaDetector/ADUVC.git


### PR DESCRIPTION
I added a new driver for USB Video Class (UVC) cameras to `areaDetector`.  Documentation has been converted to `.rst` files by Kaz Gofron, and I created an medm screen for it. I am adding a submodule for the new driver, please let me know if I missed something for the documentation auto-building.

Example UVC camera mounted at beamline:

![E-Con-Systems-See-3-Cam-mounted-at-the-XF17BM-beamline-at-NSLS2-in-the-custom-3D-printed_W640](https://user-images.githubusercontent.com/29227305/73393108-1ce69080-42a9-11ea-90e1-012c43a66fb5.jpg)

