### PR TITLE
Add .local suffix to included config files from support directory

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -32,7 +32,7 @@ CHECK_RELEASE = YES
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
 
--include $(SUPPORT)/configure/CONFIG_SITE
+-include $(SUPPORT)/configure/CONFIG_SITE.local
 -include $(AREA_DETECTOR)/configure/CONFIG_SITE.local
 -include $(AREA_DETECTOR)/configure/CONFIG_SITE.local.$(OS_CLASS)
 -include $(AREA_DETECTOR)/configure/CONFIG_SITE.local.$(EPICS_HOST_ARCH)


### PR DESCRIPTION
As far as I can tell, most other EPICS modules allow the inclusion of a file in `$(SUPPORT)/configure/CONFIG_SITE.local` or usually equivalently `$(TOP)/../configure/CONFIG_SITE.local`. Is there a reason that AreaDetector does not append the `.local` in this case?