### PR TITLE
Add script for generating release notes automatically

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -u
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <previous-tag> <current-tag>"
+  exit 1
+fi
+
+github_url="https://github.com/areaDetector"
+
+# Find all tags after a given commit for a module
+get_module_releases() {
+  module=$1
+  commit=$2
+
+  # Take commit right after the given one
+  first_commit=$(git -C $module log --format=%h --reverse $commit..HEAD | head -n 1)
+
+  tags="$(git -C $module tag --contains $first_commit)"
+
+  echo $tags
+}
+
+# Print release information of each module based on the provided commit
+print_module_releases() {
+  module=$1
+  commit=$2
+
+  read -ra tags <<< "$(get_module_releases $module $commit)"
+
+  if [ ${#tags[@]} -gt 0 ]; then
+    echo "* [$module ${tags[@]}]($github_url/$module/blob/master/RELEASE.md#${tags[-1],,})"
+  else
+    echo "* $module"
+  fi
+}
+
+previous_tag=$1
+current_tag=$2
+
+changed_files=$(git diff --name-only $previous_tag..$current_tag)
+
+printf "### $current_tag\n\n"
+
+for file in $changed_files; do
+  # Check if changed file is a submodule
+  tree_info=$(echo "$(git ls-tree $previous_tag)" | grep -oE ".*commit.*$file")
+
+  if [ -n "$tree_info" ]; then
+    module=$(echo $tree_info | cut -d' ' -f 4)
+    commit=$(echo $tree_info | cut -d' ' -f 3)
+
+    print_module_releases $module $commit
+  fi
+done

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,30 +9,41 @@ fi
 
 github_url="https://github.com/areaDetector"
 
-# Find all tags after a given commit for a module
+
+# Find all tags in a given commit range (start_commit, end_commit] for a module
 get_module_releases() {
   module=$1
-  commit=$2
+  start_commit=$2
+  end_commit=$3
 
-  # Take commit right after the given one
-  first_commit=$(git -C $module log --format=%h --reverse $commit..HEAD | head -n 1)
+  # Take commit right after the first one
+  first_commit=$(git -C $module log --format=%h --reverse $start_commit..$end_commit | head -n 1)
 
-  tags="$(git -C $module tag --contains $first_commit)"
+  tags="$(git -C $module tag --contains $first_commit --no-contains $end_commit)"
+
+  # Include `end_commit` to the range
+  tags+=" $(git -C $module tag --points-at $end_commit)"
 
   echo $tags
 }
 
-# Print release information of each module based on the provided commit
+# Print release information of each module based on the provided commit range
+# and releases
 print_module_releases() {
   module=$1
-  commit=$2
+  start_commit=$2
+  end_commit=$3
+  releases="${@:4}"
 
-  read -ra tags <<< "$(get_module_releases $module $commit)"
+  read -ra tags <<< "$releases"
+
+  release_notes_url=$github_url/$module/blob/master/RELEASE.md
+  compare_url=$github_url/$module/compare/$start_commit..$end_commit
 
   if [ ${#tags[@]} -gt 0 ]; then
-    echo "* [$module ${tags[@]}]($github_url/$module/blob/master/RELEASE.md#${tags[-1],,})"
+    echo "* [$module]($compare_url) [${tags[@]}]($release_notes_url#${tags[-1],,})"
   else
-    echo "* $module"
+    echo "* [$module]($compare_url)"
   fi
 }
 
@@ -41,16 +52,61 @@ current_tag=$2
 
 changed_files=$(git diff --name-only $previous_tag..$current_tag)
 
-printf "### $current_tag\n\n"
+tagged=()
+untagged=()
+added=()
 
 for file in $changed_files; do
-  # Check if changed file is a submodule
-  tree_info=$(echo "$(git ls-tree $previous_tag)" | grep -oE ".*commit.*$file")
+  previous_tree=$(echo "$(git ls-tree $previous_tag)" | grep -oE ".*commit.*$file")
+  current_tree=$(echo "$(git ls-tree $current_tag)" | grep -oE ".*commit.*$file")
 
-  if [ -n "$tree_info" ]; then
-    module=$(echo $tree_info | cut -d' ' -f 4)
-    commit=$(echo $tree_info | cut -d' ' -f 3)
+  if [ -z "$previous_tree" -a -z "$current_tree" ]; then
+    # Changed file is not a submodule
+    continue
+  fi
 
-    print_module_releases $module $commit
+  start_commit=$(echo $previous_tree | cut -d' ' -f 3)
+  end_commit=$(echo $current_tree | cut -d' ' -f 3)
+  module=$(echo $current_tree | cut -d' ' -f 4)
+
+  if [ -z "$previous_tree" -a -n "$current_tree" ]; then
+    start_commit=$(git -C $module rev-list --max-parents=0 --reverse HEAD | head -n 1)
+    releases=$(get_module_releases $module $start_commit $end_commit)
+
+    added+=("$module $start_commit $end_commit $releases")
+  elif [ -n "$previous_tree" -a -n "$current_tree" ]; then
+    releases=$(get_module_releases $module $start_commit $end_commit)
+
+    if [ -n "$releases" ]; then
+      tagged+=("$module $start_commit $end_commit $releases")
+    else
+      untagged+=("$module $start_commit $end_commit")
+    fi
   fi
 done
+
+printf "### $current_tag\n\n"
+
+if [ ${#tagged[@]} -gt 0 ]; then
+  printf "#### Module releases\n\n"
+
+  for module_info in "${tagged[@]}"; do
+    print_module_releases $module_info
+  done
+fi
+
+if [ ${#untagged[@]} -gt 0 ]; then
+  printf "\n#### Modules with untagged updates\n\n"
+
+  for module_info in "${untagged[@]}"; do
+    print_module_releases $module_info
+  done
+fi
+
+if [ ${#added[@]} -gt 0 ]; then
+  printf "\n#### New modules\n\n"
+
+  for module_info in "${added[@]}"; do
+    print_module_releases $module_info
+  done
+fi


### PR DESCRIPTION
Based on a collaboration meeting discussion, I've written a script to generate the release notes for arbitrary tags (actually, commits) from this top-level repository with proper links for corresponding release notes. The generated sections are the following:

- **Module releases.** Tagged modules are the ones that were `git-tag`ed in the release commit range. Such modules have well-defined release notes that document the changes, which are linked¹.
- **Modules with untagged updates.** They do not necessarily have partial release notes, so only their changeset (rendered by GitHub) is linked instead.
- **New modules,**  listed in the same format used by (un)tagged modules, but in a separate section to make clear they weren't previously available.

A "removed modules" section could be also created. However, an unexpected behavior of `git-diff(1)` is that it does not include removed submodules in its output. Thus, another approach should be taken for that.

I decided to script that in bash, since it is basically a manipulation of several `git` commands. Let me know if you think that might become a maintainability issue.