### PR TITLE
Make docs build reusable, upload docs html as artifact. Add building docs to CI

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,9 +16,9 @@ jobs:
         submodules: "true"
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
-        python-version: "3.10"
+        python-version: "3.13"
 
     - name: Build Sphinx Docs
       run: |

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,42 @@
+name: Build Sphinx Docs
+
+on:
+  workflow_call:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: "true"
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Build Sphinx Docs
+      run: |
+        pip install -r requirements.txt
+        cd docs
+        make sphinx
+        cd -
+
+    - name: Install Doxygen
+      run: sudo apt-get install doxygen graphviz -y
+
+    - name: Generate Doxygen Documentation
+      run: |
+        cd docs
+        make doxygen
+        cd -
+
+    - name: Upload Docs Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs-html
+        path: docs/_build/html

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,7 +4,8 @@ on:
   workflow_call:
 
 jobs:
-  build-docs:
+  build:
+    name: Build Sphinx Docs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,4 +1,4 @@
-name: Check Docs Build
+name: Check
 
 on:
   push:
@@ -9,5 +9,6 @@ on:
       - master
 
 jobs:
-  build-docs:
+  test-build:
+    name: Test Build
     uses: ./.github/workflows/build-docs.yml

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,13 @@
+name: Check Docs Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-docs:
+    uses: ./.github/workflows/build-docs.yml

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,4 +1,4 @@
-name: Publish Sphinx Docs to GitHub Pages
+name: Publish
 on:
   push:
     tags:
@@ -14,9 +14,11 @@ on:
 jobs:
 
   build-docs:
+    name: Build Sphinx Docs
     uses: ./.github/workflows/build-docs.yml
 
   publish-docs:
+    name: Publish Sphinx Docs
     runs-on: ubuntu-latest
     needs: build-docs
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,10 +1,6 @@
 name: Publish Sphinx Docs to GitHub Pages
 on:
-  # Build the docs on pushes to main branch, PRs to main branch, and new tags.
-  # Publish only on demand.
   push:
-    branches:
-      - master
     tags:
       - '*'  # all tags
   workflow_dispatch:   # allow manual triggering
@@ -15,56 +11,29 @@ on:
         required: true
         default: false
 
-
-# see: https://sphinx-notes.github.io/pages/
-# see: https://github.com/marketplace/actions/sphinx-to-github-pages
-
 jobs:
 
   build-docs:
+    uses: ./.github/workflows/build-docs.yml
+
+  publish-docs:
     runs-on: ubuntu-latest
+    needs: build-docs
 
     steps:
     - name: Deploy Information
       if: ${{ github.event.inputs.deploy }}
       run: |
-        echo "The will be published from this workflow run."
+        echo "The docs will be published from this workflow run."
 
-    - name: Checkout
-      uses: actions/checkout@master
+    - name: Download Docs Artifact
+      uses: actions/download-artifact@v4
       with:
-        fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
-        submodules: "true"
-
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-
-    - name: Build Docs
-      run: |
-        pip install m2r2 "pygments >=2.7.0" "sphinx_rtd_theme >=1.2.0" sphinx-multibuild linuxdoc "docutils<=0.20.1"
-        cd docs
-        make sphinx
-        cd -
-        #sphinx-build -ET docs/source docs/_build/html/
-
-    - name: Install Doxygen
-      run: sudo apt-get install doxygen graphviz -y
-      shell: bash
-
-    - name: Generate Doxygen Documentation
-      # Doxygen output is put in _build/html/doxy_output/html by the Doxyfile
-      # So it will be published by Publish Jobs below
-      run: |
-        cd docs
-        make doxygen
-        cd -
-        ls -l docs/_build/html
+        name: docs-html
+        path: docs-html
 
     - name: Publish Docs
       uses: peaceiris/actions-gh-pages@v3.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_build/html
-        #keep_files: true
+        publish_dir: docs-html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'sphinx.ext.extlinks',
               'sphinx.ext.napoleon',
+              'sphinx.ext.todo',
               'm2r2',
               'linuxdoc.rstFlatTable'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,10 @@
-sphinx==1.8.5
-Jinja2<3.1
-markupsafe<2.1
+sphinx>=7.2,<8
 sphinx-bootstrap-theme
-m2r
 m2r2
 pygments>=2.7.0
 sphinx_rtd_theme>=1.2.0
 mistune==0.8.4
 sphinx-multibuild
 linuxdoc
-docutils<=0.20.1
+docutils>=0.18,<=0.20.1
 breathe

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 sphinx==1.8.5
+Jinja2<3.1
+markupsafe<2.1
 sphinx-bootstrap-theme
 m2r
 m2r2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 sphinx==1.8.5
 sphinx-bootstrap-theme
 m2r
+m2r2
+pygments>=2.7.0
+sphinx_rtd_theme>=1.2.0
 mistune==0.8.4
 sphinx-multibuild
+linuxdoc
+docutils<=0.20.1
 breathe


### PR DESCRIPTION
This will allow for dependabot updates to automatically be checked, along with any additions of new drivers/versions.

The successfully built docs can be downloaded as an artifact from here: https://github.com/areaDetector/areaDetector/actions/runs/27362535030

The GH workflows were also installing the python packages themselves rather than using the requirements file, I changed them to use the file so we need to only maintain the dependency list in one place.